### PR TITLE
include package startup message to point to citations

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,28 @@
+
+
+.onAttach <- function(libname, pkgname) {
+
+    .startup_message <-
+"
+  ___          ____  ___ __     __ ___  ____   _   ___
+ / _ \\ __  __ / ___|/ _ \\\\ \\   / /|_ _||  _ \\ / | / _ \\
+| | | |\\ \\/ /| |   | | | |\\ \\ / /  | | | | | || || (_) |
+| |_| | >  < | |___| |_| | \\ V /   | | | |_| || | \\__, |
+ \\___/ /_/\\_\\ \\____|\\___/   \\_/   |___||____/ |_|   /_/
+ ___           _          _
+|  _ \\   __ _ | |_  __ _ | |__    __ _  ___   ___
+| | | | / _` || __|/ _` || '_ \\  / _` |/ __| / _ \\
+| |_| || (_| || |_| (_| || |_) || (_| |\\__ \\|  __/
+|____/  \\__,_| \\__|\\__,_||_.__/  \\__,_||___/ \\___|
+
+The OxCOVID19 Database makes use of several datasets. If you
+use any of the data provided by this package, please include
+the appropriate citation as described at the following
+website:
+
+https://covid19.eng.ox.ac.uk/data_sources.html
+
+"
+
+    packageStartupMessage(.startup_message)
+}


### PR DESCRIPTION
Include a message when the package is loaded pointing to the website with information about how to cite the original data source. It might be a good idea to extend this message to include examples of the citations, and of the package itself.